### PR TITLE
Update AssemblyInfo.cs

### DIFF
--- a/Westwind.Web.WebForms/Properties/AssemblyInfo.cs
+++ b/Westwind.Web.WebForms/Properties/AssemblyInfo.cs
@@ -2,6 +2,10 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+// Not sure why this is needed but without it get errors in Globalization project:
+//  Inheritance security rules violated by type: 'Westwind.Web.Controls.ScriptContainerDesigner'. Derived types must either match the security accessibility of the base type or be less accessible.
+[assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level1)]
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.


### PR DESCRIPTION
Fixes runtime error ' Inheritance security rules violated' when running Westwind.GlobalizationWeb (Resource Localization editor). GlobalizationWeb has Westwind.Web.WebForms as a dependency. 

This workaround also exists in Westwind.Web
