### PR TITLE
Update ConfigurationFileConfigurationProvider.cs

### DIFF
--- a/Westwind.Utilities/Configuration/Providers/ConfigurationFileConfigurationProvider.cs
+++ b/Westwind.Utilities/Configuration/Providers/ConfigurationFileConfigurationProvider.cs
@@ -2,7 +2,7 @@
 /*
  **************************************************************
  *  Author: Rick Strahl 
- *          © West Wind Technologies, 2009-2013
+ *          Â© West Wind Technologies, 2009-2013
  *          http://www.west-wind.com/
  * 
  * Created: 09/12/2009
@@ -166,7 +166,7 @@ namespace Westwind.Utilities.Configuration
                 else
                     continue;
 
-                string fieldName = Member.Name.ToLower();
+                string fieldName = Member.Name.ToLowerInvariant();
 
                 // Error Message is an internal public property
                 if (fieldName == "errormessage" || fieldName == "provider")


### PR DESCRIPTION
If the thread culture is Turkish ("tr-TR") or Azerbaijani ("az") and the member name includes capital 'i', configuration changes occur everytime when the Read method is called. The source of the problem is explained in the following MSDN article. In my case:
System.Threading.Thread.CurrentThread.CurrentCulture: {tr-TR}
Member.Name: ShowControlIcons
Member.Name.ToLower(): showcontrolıcons
Member.Name.ToLowerInvariant(): showcontrolicons

https://msdn.microsoft.com/en-us/library/dd465121(v=vs.110).aspx: "For nearly all Latin alphabets, including U.S. English, the character "i" (\u0069) is the lowercase version of the character "I" (\u0049). This casing rule quickly becomes the default for someone programming in such a culture. However, the Turkish ("tr-TR") alphabet includes an "I with a dot" character "İ" (\u0130), which is the capital version of "i". Turkish also includes a lowercase "i without a dot" character, "ı" (\u0131), which capitalizes to "I". This behavior occurs in the Azerbaijani ("az") culture as well."