### PR TITLE
Changed EscapeUriString to EscapeDataString in UrlEncodingParser.ToSt…

### DIFF
--- a/Westwind.Utilities/SupportClasses/UrlEncodingParser.cs
+++ b/Westwind.Utilities/SupportClasses/UrlEncodingParser.cs
@@ -129,7 +129,7 @@ namespace Westwind.Utilities
 
                 foreach (var val in values)
                 {
-                    query += key + "=" + Uri.EscapeUriString(val) + "&";
+                    query += key + "=" + Uri.EscapeDataString(val) + "&";
                 }
             }
             query = query.Trim('&');


### PR DESCRIPTION
…ring()

For correct handling of values with plus signs, e.g. "Visual C++".
